### PR TITLE
high cpu load due to wrong version of redis-py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY deployment/docker/nginx.conf /etc/nginx/nginx.conf
 
 RUN pip3 install -U pip setuptools wheel typing && \
     pip3 install -e /pretalx/src/ && \
-    pip3 install django-redis pylibmc mysqlclient psycopg2-binary redis==2.10.6 && \
+    pip3 install django-redis pylibmc mysqlclient psycopg2-binary redis==3.3.1 && \
     pip3 install gunicorn
 
 


### PR DESCRIPTION
Since running pretalx v1.0.3 the CPU load of the Docker container increased dramatically. 

scenario:
`pretalx taskworker` tries to come but crashes every time. 

reason: 

`[2019-07-29 20:20:53,697: CRITICAL/MainProcess] Unrecoverable error: VersionMismatch('Redis transport requires redis-py versions 3.2.0 or later. You have 2.10.6',)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/kombu/transport/virtual/base.py", line 921, in create_channel
    return self._avail_channels.pop()
IndexError: pop from empty list`

solution:
fixed pretalx dependency of redis-py version in Dockerfile to 3.3.1