### PR TITLE
Fix link to traefik docs in reverse-proxy-examples/docker-compose

### DIFF
--- a/reverse-proxy-examples/docker-compose/Readme.md
+++ b/reverse-proxy-examples/docker-compose/Readme.md
@@ -1,3 +1,3 @@
 # Traefik-config for pretalx
 This includes basic config to run traefik as an reverse proxy for pretalx.
-A more in-depth-guide can be found under https://docs.traefik.io/user-guide/docker-and-lets-encrypt/
+A more in-depth-guide can be found under <https://doc.traefik.io/traefik/user-guides/docker-compose/acme-tls/>


### PR DESCRIPTION
The old link was broken