### PR TITLE
Fix Docker image with new version requiring JS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
 ENV LC_ALL=C.UTF-8
 
 
+COPY pretalx/pyproject.toml /pretalx
 COPY pretalx/src /pretalx/src
 COPY deployment/docker/pretalx.bash /usr/local/bin/pretalx
 COPY deployment/docker/supervisord.conf /etc/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY deployment/docker/supervisord.conf /etc/supervisord.conf
 
 RUN pip3 install -U pip setuptools wheel typing && \
     pip3 install -e /pretalx/ && \
-    pip3 install django-redis pylibmc mysqlclient psycopg2-binary redis==3.3.1 && \
+    pip3 install django-redis pylibmc mysqlclient psycopg2-binary redis && \
     pip3 install gunicorn
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ COPY deployment/docker/pretalx.bash /usr/local/bin/pretalx
 COPY deployment/docker/supervisord.conf /etc/supervisord.conf
 
 RUN pip3 install -U pip setuptools wheel typing && \
-    pip3 install -e /pretalx/ && \
-    pip3 install django-redis pylibmc mysqlclient psycopg2-binary redis && \
+    pip3 install -e /pretalx/[mysql,postgres,redis] && \
+    pip3 install pylibmc && \
     pip3 install gunicorn
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.10-bookworm
 
 RUN apt-get update && \
     apt-get install -y git gettext libmariadb-dev libpq-dev locales libmemcached-dev build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,20 @@ RUN pip3 install -U pip setuptools wheel typing && \
 
 
 RUN python3 -m pretalx makemigrations
-RUN python3 -m pretalx migrate && python3 -m pretalx rebuild
+RUN python3 -m pretalx migrate
+
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    python3 -m pretalx rebuild && \
+    apt-get remove -y nodejs npm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN chmod +x /usr/local/bin/pretalx && \
     cd /pretalx/src && \
     rm -f pretalx.cfg && \
     chown -R pretalxuser:pretalxuser /pretalx /data && \
     rm -f /pretalx/src/data/.secret
-
-
 
 USER pretalxuser
 VOLUME ["/etc/pretalx", "/data"]

--- a/deployment/docker/pretalx.bash
+++ b/deployment/docker/pretalx.bash
@@ -30,7 +30,7 @@ if [ "$1" == "webworker" ]; then
         --max-requests "${GUNICORN_MAX_REQUESTS}" \
         --max-requests-jitter "${GUNICORN_MAX_REQUESTS_JITTER}" \
         --log-level=info \
-        --bind=127.0.0.1:80
+        --bind=0.0.0.0:80
 fi
 
 if [ "$1" == "taskworker" ]; then


### PR DESCRIPTION
Fixes #45 

- upgraded base image to bookworm:  we could also install nodejs 18 on bullseye with something along the lines of
```
curl https://nodejs.org/dist/v18.17.1/node-v18.17.1-linux-x64.tar.xz
tar -xJvf node-v18.17.1-linux-x64.tar.xz -C /usr/local/lib/nodejs 
```
- maybe in the long term we want to devise a way to cleverly use multi-stage builds to have a more readable Dockerfile. But I ended up getting frustrated on thinking about which files need to be copied from where. Ideally I'd just "squash" some build steps of the image. See also this clever trick with `RUN --mount`: https://github.com/moby/moby/issues/34565#issuecomment-778223790