### PR TITLE
Split Dockerfile commands to allow build to succeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,12 @@ RUN python3 -m pretalx migrate
 
 RUN apt-get update && \
     apt-get install -y nodejs npm && \
+    npm -v && \
+    node -v && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    python3 -m pretalx rebuild
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pretalx rebuild
 
 RUN chmod +x /usr/local/bin/pretalx && \
     cd /pretalx/src && \


### PR DESCRIPTION
For some reason the docker build was failing for linux/arm64, not sure why, but adding `npm -v` seems to fix the issue.

See: https://github.com/Shuttleu/pretalx-docker/actions/runs/8204263871

Note: I was unable to get the build to fail locally, it only seemed to fail for the github workflow