### PR TITLE
55: Allow changing the listen port for gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ This repository contains a docker-compose setup as well as an [ansible](https://
   is located at ``reverse-proxy-examples/docker-compose``. You can also find a few words on an nginx configuration at
   ``reverse-proxy-examples/nginx``
 * Make sure you serve all requests for the `/static/` and `/media/` paths (when `debug=false`). See [installation](https://docs.pretalx.org/administrator/installation/#step-7-ssl) for more information
-* Optional: To adjust the number of [Gunicorn workers](https://docs.gunicorn.org/en/stable/settings.html#workers), provide
-  the container with `GUNICORN_WORKERS` environment variable. Similarly you can use `GUNICORN_MAX_REQUESTS` and
-  `GUNICORN_MAX_REQUESTS_JITTER` to configure the requests a worker instance will process before restarting. `GUNICORN_FORWARDED_ALLOW_IPS` lets you specify which IPs to trust (i.e. which reverse proxies' `X-Forwarded-*` headers can be used to infer connection security).
+* Optional: Some of the Gunicorn parameters can be adjusted via environment viariables:
+  * To adjust the number of [Gunicorn workers](https://docs.gunicorn.org/en/stable/settings.html#workers), provide
+  the container with `GUNICORN_WORKERS` environment variable.
+  * `GUNICORN_MAX_REQUESTS` and `GUNICORN_MAX_REQUESTS_JITTER` to configure the requests a worker instance will process before restarting.
+  * `GUNICORN_FORWARDED_ALLOW_IPS` lets you specify which IPs to trust (i.e. which reverse proxies' `X-Forwarded-*` headers can be used to infer connection security). 
+  * `GUNICORN_BIND_ADDR` can be used to change the interface and port that Gunicorn will listen on. Default: `0.0.0.0:80`
+  
   Here's how to set an environment variable [in
   `docker-compose.yml`](https://docs.docker.com/compose/environment-variables/set-environment-variables/)
   or when using [`docker run` command](https://docs.docker.com/engine/reference/run/#env-environment-variables).

--- a/deployment/docker/pretalx.bash
+++ b/deployment/docker/pretalx.bash
@@ -11,6 +11,7 @@ GUNICORN_WORKERS="${GUNICORN_WORKERS:-${WEB_CONCURRENCY:-$((2 * $(nproc)))}}"
 GUNICORN_MAX_REQUESTS="${GUNICORN_MAX_REQUESTS:-1200}"
 GUNICORN_MAX_REQUESTS_JITTER="${GUNICORN_MAX_REQUESTS_JITTER:-50}"
 GUNICORN_FORWARDED_ALLOW_IPS="${GUNICORN_FORWARDED_ALLOW_IPS:-127.0.0.1}"
+GUNICORN_BIND_ADDR="${GUNICORN_BIND_ADDR:-0.0.0.0:80}"
 
 AUTOMIGRATE="${AUTOMIGRATE:-yes}"
 AUTOREBUILD="${AUTOREBUILD:-yes}"
@@ -58,7 +59,7 @@ if [ "$1" == "webworker" ]; then
         --max-requests-jitter "${GUNICORN_MAX_REQUESTS_JITTER}" \
         --forwarded-allow-ips "${GUNICORN_FORWARDED_ALLOW_IPS}" \
         --log-level=info \
-        --bind=0.0.0.0:80
+        --bind="${GUNICORN_BIND_ADDR}"
 fi
 
 if [ "$1" == "taskworker" ]; then


### PR DESCRIPTION
- This PR will resolve issue #55 by allowing admins to configure gunicorn to listen on any non-privileged port (>1024). Listening on privileged ports can cause issues on hardened Kubernetes clusters and runtimes such as Podman, as discussed in a [related Kubernetes issue](https://github.com/kubernetes/kubernetes/issues/56374)