### PR TITLE
fix: pass environment variables down through supervisord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     mkdir /public && \
     groupadd -g 999 pretalxuser && \
     useradd -r -u 999 -g pretalxuser -d /pretalx -ms /bin/bash pretalxuser && \
-    echo 'pretalxuser ALL=(ALL) NOPASSWD: /usr/bin/supervisord' >> /etc/sudoers
+    echo 'pretalxuser ALL=(ALL) NOPASSWD:SETENV: /usr/bin/supervisord' >> /etc/sudoers
 
 ENV LC_ALL=C.UTF-8
 

--- a/deployment/docker/pretalx.bash
+++ b/deployment/docker/pretalx.bash
@@ -48,7 +48,7 @@ if [ "$AUTOMIGRATE" = "yes" ]; then
 fi
 
 if [ "$1" == "all" ]; then
-    exec sudo /usr/bin/supervisord -n -c /etc/supervisord.conf
+    exec sudo -E /usr/bin/supervisord -n -c /etc/supervisord.conf
 fi
 
 if [ "$1" == "webworker" ]; then


### PR DESCRIPTION
https://github.com/pretalx/pretalx-docker/pull/61 allowed setting GUNICORN_BIND_ADDR, but environment variables were never passed down through `sudo` into `supervisord`, so this had no effect.

This PR fixes that by passing all environment variables down to `supervisord`. This additionally allows to completely skip a config file and configure pretalx entirely through env variables instead.

For the time being until this is merged and released I have published a hotfixed version myself:
https://hub.docker.com/repository/docker/dasprid/pretalx-standalone/general