### PR TITLE
feat(dockerfile): multi-stage build, reduces image size ~2x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,50 @@
+FROM python:3.14-slim-trixie AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git gettext \
+        libmariadb-dev libpq-dev libmemcached-dev build-essential \
+        nodejs npm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --chown=root:root pretalx/pyproject.toml /pretalx/
+COPY --chown=root:root pretalx/src /pretalx/src
+
+RUN pip3 install --no-cache-dir -U pip setuptools wheel && \
+    pip3 install --no-cache-dir -e /pretalx/[mysql,postgres,redis] && \
+    pip3 install --no-cache-dir pylibmc gunicorn
+
+RUN python3 -m pretalx rebuild && \
+    rm -f /pretalx/src/pretalx.cfg /pretalx/src/data/.secret
+
+
 FROM python:3.14-slim-trixie
 
 RUN apt-get update && \
-    apt-get install -y git gettext libmariadb-dev libpq-dev locales libmemcached-dev build-essential \
-            supervisor \
-            locales \
-            --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+        gettext locales \
+        libmariadb3 libpq5 libmemcached11t64 \
+        supervisor && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     dpkg-reconfigure locales && \
     locale-gen C.UTF-8 && \
     /usr/sbin/update-locale LANG=C.UTF-8 && \
-    mkdir /etc/pretalx && \
-    mkdir /data && \
-    mkdir /public && \
+    mkdir /etc/pretalx /data /public && \
     groupadd -g 999 pretalxuser && \
     useradd -r -u 999 -g pretalxuser -d /pretalx -ms /bin/bash pretalxuser
 
 ENV LC_ALL=C.UTF-8
 
-COPY --chown=pretalxuser:pretalxuser pretalx/pyproject.toml /pretalx
-COPY --chown=pretalxuser:pretalxuser pretalx/src /pretalx/src
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/bin/gunicorn /usr/local/bin/celery /usr/local/bin/
+COPY --from=builder /pretalx /pretalx
+
 COPY --chown=root:root deployment/docker/pretalx.bash /usr/local/bin/pretalx
 COPY --chown=root:root deployment/docker/supervisord.conf /etc/supervisord.conf
 
-RUN pip3 install -U pip setuptools wheel typing && \
-    pip3 install -e /pretalx/[mysql,postgres,redis] && \
-    pip3 install pylibmc && \
-    pip3 install gunicorn
-
-RUN apt-get update && \
-    apt-get install -y nodejs npm && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN chmod +x /usr/local/bin/pretalx
-
-RUN python3 -m pretalx makemigrations && \
-    python3 -m pretalx migrate && \
-    python3 -m pretalx rebuild && \
-    rm -f /pretalx/src/pretalx.cfg && \
-    rm -f /pretalx/src/data/.secret && \
+RUN chmod +x /usr/local/bin/pretalx && \
     chown -R pretalxuser:pretalxuser /pretalx /data /public /etc/pretalx
 
 USER pretalxuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gettext locales \
         libmariadb3 libpq5 libmemcached11t64 \
+        nodejs npm \
         supervisor && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
I was building the image locally and it was a bit large.

I split the image into two steps:

1. Builder stage: It installs the compilers and the dependencies for databases (to build pylibmc) - and builds the static assets
2. Final: Uses a fresh base image, where it copies in what it needs to run pretalx (without the builder and dev headers for databases). It got shrunk from ~518mb to ~223. 

I also took the liberty in removing `makemigrations` as I dont think it makes sense to include it in the production image, since it runs with entrypoint: https://github.com/pretalx/pretalx-docker/blob/9a93532a181b12357d4697999b5ec8c3d08b40e9/deployment/docker/pretalx.bash#L15-L17

Added `--no-cache-dir` to the pip calls to prevent cache to be added in the layers
Merged the two `apt` calls into one, so that there is a layer less
Removed the `typing` package from pip as it is part of stdlib since python 3.5 

I am currently using this image on my own instance, and thought that others in the community may benefit from this as well :fox_face:

Note: I initially said 10x decrease in size - I read the wrong numbers upon checking it earlier, sorry (which was the whole reason I went ahead and did this PR... but still an improvement)
